### PR TITLE
Issue:2523 Validation fails for default reader_Id in kafka-adapter

### DIFF
--- a/kafka-adapter/src/main/java/io/pravega/adapters/kafka/client/consumer/PravegaKafkaConsumer.java
+++ b/kafka-adapter/src/main/java/io/pravega/adapters/kafka/client/consumer/PravegaKafkaConsumer.java
@@ -130,7 +130,7 @@ public class PravegaKafkaConsumer<K, V> implements Consumer<K, V> {
         scope = config.getScope() != null ? config.getScope() : PravegaConfig.DEFAULT_SCOPE;
         deserializer = config.getSerializer();
         readerGroupId = config.evaluateGroupId(UUID.randomUUID().toString());
-        readerId = config.evaluateClientId("default_readerId");
+        readerId = config.evaluateClientId("default-readerId");
         interceptors = (List) (new ConsumerConfig(configProperties)).getConfiguredInstances(
                 ConsumerConfig.INTERCEPTOR_CLASSES_CONFIG, ConsumerInterceptor.class);
         readTimeout = config.getReadTimeoutInMs();


### PR DESCRIPTION
Signed-off-by: Shwetha N <shwetha.n1@dell.com>
**Change log description**
Change default readerID in kafka-adapter to "default-readerID".

**Purpose of the change**
 Fixes #5 

**What code does**
Default readerID in kafka-adapter is "default_readerID", as per pravega Reader name validation it does not support "_" .
Change default value to "default-readerID".
